### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-docs.macgap.com
+


### PR DESCRIPTION
I think this should make it so going to http://macgapproject.github.io/documentation/ stops redirecting to the spammy docs.macgap.com link.  Once this has happened, we can clean up all links to http://macgapproject.github.io/documentation/ for documentation and it should go to the github pages version of the site.  Not sure though as I haven't worked with jekyll before.