### PR TITLE
Updating doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation for MacGap 2
 
-The documentation is available at http://docs.macgap.com
+The documentation is available at https://macgapproject.github.io/documentation/
 
 ### Contributing
 
@@ -12,7 +12,7 @@ We would love your help improving this documentation:
 
 We would also like:
 
-* CSS / HTML theming help (see http://docs.macgap.com for how it looks right now)
+* CSS / HTML theming help (see https://macgapproject.github.io/documentation/ for how it looks right now)
 
 ### Getting started
 

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ sections: [
 
 # Keep as an empty string if served up at the root. If served up at a specific
 # path (e.g. on GitHub pages) leave off the trailing slash, e.g. /my-project
-baseurl: ''
+baseurl: '/documentation'
 
 # Dates are not included in permalinks
 permalink: none

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ subtitle: 'Desktop WebKit wrapper for HTML/CSS/JS applications.'
 navigation: 2
 
 # URL to source code, used in _includes/footer.html
-codeurl: 'http://docs.macgap.com/'
+codeurl: 'https://macgapproject.github.io/documentation/'
 
 # Default categories (in order) to appear in the navigation
 sections: [

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ sections: [
 
 # Keep as an empty string if served up at the root. If served up at a specific
 # path (e.g. on GitHub pages) leave off the trailing slash, e.g. /my-project
-baseurl: ''
+baseurl: 'https://macgapproject.github.io/documentation/'
 
 # Dates are not included in permalinks
 permalink: none

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ sections: [
 
 # Keep as an empty string if served up at the root. If served up at a specific
 # path (e.g. on GitHub pages) leave off the trailing slash, e.g. /my-project
-baseurl: 'https://macgapproject.github.io/documentation/'
+baseurl: ''
 
 # Dates are not included in permalinks
 permalink: none

--- a/_posts/2014-06-03-window.md
+++ b/_posts/2014-06-03-window.md
@@ -85,7 +85,7 @@ MacGap.Window.resize(500, 300);
 
 Change the window title to newTitle.
 
-NOTE: when first opened, the window title is specified in the `config.json` configuration file. See (App Configuration)[http://docs.macgap.com/doc/app-configuration.html].
+NOTE: when first opened, the window title is specified in the `config.json` configuration file. See (App Configuration)[https://macgapproject.github.io/documentation/doc/app-configuration.html].
 
 *Example usage*
 

--- a/_posts/2014-06-13-customising.md
+++ b/_posts/2014-06-13-customising.md
@@ -9,12 +9,12 @@ order: 3
 
 ### How to change the project name in Xcode
 
-*This documentation is incomplete. Please help us by [contributing your knowledge](http://docs.macgap.com/doc/contributing.html)*
+*This documentation is incomplete. Please help us by [contributing your knowledge](https://macgapproject.github.io/documentation/doc/contributing.html)*
 
 ### How to build and package your app for distribution
 
-*This documentation is incomplete. Please help us by [contributing your knowledge](http://docs.macgap.com/doc/contributing.html)*
+*This documentation is incomplete. Please help us by [contributing your knowledge](https://macgapproject.github.io/documentation/doc/contributing.html)*
 
 ### Building for Mac App Store submission
 
-*This documentation is incomplete. Please help us by [contributing your knowledge](http://docs.macgap.com/doc/contributing.html)*
+*This documentation is incomplete. Please help us by [contributing your knowledge](https://macgapproject.github.io/documentation/doc/contributing.html)*


### PR DESCRIPTION
Updating links to go to https://macgapproject.github.io/documentation/
from spammy docs.macgap.com